### PR TITLE
Use the 'immutable' Cache-Control directive for long-lived assets

### DIFF
--- a/waiter/lib/travis/web/app.rb
+++ b/waiter/lib/travis/web/app.rb
@@ -162,7 +162,7 @@ class Travis::Web::App
     def cache_control(file)
       case path_for(file)
       when '/'        then "public, must-revalidate, max-age=0"
-      else "public, max-age=#{age}"
+      else "public, max-age=#{age}, immutable"
       end
     end
 

--- a/waiter/spec/app_spec.rb
+++ b/waiter/spec/app_spec.rb
@@ -9,8 +9,7 @@ describe Travis::Web::App do
     before  { get('/foo/bar') }
     example { last_response.should be_ok }
     example { headers['Content-Location'].should be == '/' }
-    example { headers['Cache-Control'].should include('must-revalidate') }
-    example { headers['Cache-Control'].should include('public') }
+    example { headers['Cache-Control'].should be == 'public, must-revalidate, max-age=0' }
     example { headers['Vary'].should include('Accept') }
   end
 
@@ -18,8 +17,7 @@ describe Travis::Web::App do
     before  { get('/favicon.ico') }
     example { last_response.should be_ok }
     example { headers['Content-Location'].should be == '/favicon.ico' }
-    example { headers['Cache-Control'].should_not include('must-revalidate') }
-    example { headers['Cache-Control'].should include('public') }
+    example { headers['Cache-Control'].should be == 'public, max-age=31536000, immutable' }
     example { headers['Vary'].split(',').should_not include('Accept') }
   end
 end


### PR DESCRIPTION
This adds the `immutable` directive to fingerprinted assets that already had a 1-year max-age, to avoid unnecessary HTTP 304 requests.

Before:
`Cache-Control: public, max-age=31536000`

After:
`Cache-Control: public, max-age=31536000, immutable`

See:
https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/
https://code.facebook.com/posts/557147474482256/this-browser-tweak-saved-60-of-requests-to-facebook/

Is the `travis-web-index` port of travis-ci/travis-web#1375, which refs travis-ci/travis-ci#8601.